### PR TITLE
Fix SSH control channel usage and add missing lastz_seqs table

### DIFF
--- a/.ci/jenkins.sh
+++ b/.ci/jenkins.sh
@@ -75,7 +75,7 @@ BUILD_GALAXY_UP=false
 function trap_handler() {
     { set +x; } 2>/dev/null
     # return to original dir
-    while popd; do :; done || true
+    while popd 2>/dev/null; do :; done || true
     $IMPORT_CONTAINER_UP && stop_import_container
     clean_preconfigured_container
     $LOCAL_CVMFS_MOUNTED && unmount_overlay
@@ -302,7 +302,7 @@ function start_ssh_control() {
     log "Starting SSH control connection to Stratum 0"
     SSH_MASTER_SOCKET="${SSH_MASTER_SOCKET_DIR}/ssh-tunnel-${REPO_USER}-${REPO_STRATUM0}.sock"
     log_exec mkdir -p "$SSH_MASTER_SOCKET_DIR"
-    log_exec ssh -S "$SSH_MASTER_SOCKET" -Nfn -l "$REPO_USER" "$REPO_STRATUM0"
+    log_exec ssh -M -S "$SSH_MASTER_SOCKET" -Nfn -l "$REPO_USER" "$REPO_STRATUM0"
     USER_UID=$(exec_on id -u)
     USER_GID=$(exec_on id -g)
     SSH_MASTER_UP=true

--- a/config/tool_data_table_conf.xml
+++ b/config/tool_data_table_conf.xml
@@ -19,6 +19,10 @@
         <columns>value, path</columns>
         <file path="/cvmfs/idc.galaxyproject.org/config/twobit.loc"/>
     </table>
+    <table name="lastz_seqs" comment_char="#">
+        <columns>value, name, path</columns>
+        <file path="/cvmfs/idc.galaxyproject.org/config/lastz_seqs.loc" />
+    </table>
     <table name="alignseq_seq" comment_char="#">
         <columns>type, value, path</columns>
         <file path="/cvmfs/idc.galaxyproject.org/config/alignseq.loc"/>


### PR DESCRIPTION
This should also cause the import of twobit DM data for all genomes and the danRer10 STAR and sam indexes, which failed last go around. I manually removed these from the `record` dir in CVMFS.