### PR TITLE
Add missing lastz_seqs table for twobit

### DIFF
--- a/config/tool_data_table_conf.xml
+++ b/config/tool_data_table_conf.xml
@@ -19,6 +19,10 @@
         <columns>value, path</columns>
         <file path="/cvmfs/idc.galaxyproject.org/config/twobit.loc"/>
     </table>
+    <table name="lastz_seqs" comment_char="#">
+        <columns>value, name, path</columns>
+        <file path="/cvmfs/idc.galaxyproject.org/config/lastz_seqs.loc" />
+    </table>
     <table name="alignseq_seq" comment_char="#">
         <columns>type, value, path</columns>
         <file path="/cvmfs/idc.galaxyproject.org/config/alignseq.loc"/>


### PR DESCRIPTION
Not deployable until bundle transfers are fixed, but I didn't want to lose it.